### PR TITLE
bug/websocket 통신시 405 오류 발생

### DIFF
--- a/chat-api/src/main/resources/db/changelog/250815-update-column-group.yaml
+++ b/chat-api/src/main/resources/db/changelog/250815-update-column-group.yaml
@@ -1,0 +1,25 @@
+databaseChangeLog:
+  - changeSet:
+      id: 1
+      author: yeeun
+      context: chat
+      changes:
+        - update:
+            tableName: "group"
+            columns:
+              - column:
+                  name: tag
+                  valueComputed: "JSON_UNQUOTE(tag)"
+            where: "JSON_VALID(JSON_UNQUOTE(tag))"
+
+  - changeSet:
+      id: 2
+      author: yeeun
+      context: chat
+      changes:
+        - sql:
+            sql: |
+              -- 변환 결과 확인용 (운영 반영 전 데이터 검증)
+              SELECT id, tag
+              FROM `group`
+              WHERE JSON_VALID(tag) = 0 OR JSON_TYPE(tag) != 'ARRAY';

--- a/chat-api/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/chat-api/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -9,3 +9,5 @@ databaseChangeLog:
       file: db/changelog/250810-create-table-quest.yaml
   - include:
       file: db/changelog/250812-update-table-users.yaml
+  - include:
+      file: db/changelog/250815-update-column-group.yaml

--- a/chat-websocket/src/main/java/com/nameless/social/websocket/ChatWebsocketApplication.java
+++ b/chat-websocket/src/main/java/com/nameless/social/websocket/ChatWebsocketApplication.java
@@ -1,6 +1,7 @@
 package com.nameless.social.websocket;
 
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
@@ -10,6 +11,9 @@ import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfigurat
 @EnableAutoConfiguration(exclude = {DataSourceAutoConfiguration.class, HibernateJpaAutoConfiguration.class})
 public class ChatWebsocketApplication {
 	public static void main(String[] args) {
-		SpringApplication.run(ChatWebsocketApplication.class, args);
+		// WebFlux 의존성은 WebClient를 사용하는 데만 활용되고, 애플리케이션의 전체 동작은 안정적인 Spring MVC를 기반으로 하게 되어 SockJS 핸드셰이크 문제를 해결
+		SpringApplication application = new SpringApplication(ChatWebsocketApplication.class);
+		application.setWebApplicationType(WebApplicationType.SERVLET);
+		application.run(args);
 	}
 }


### PR DESCRIPTION
- /ws/info로 SockJS가 요청을 보낼 때 405 Method Not Allowed가 발생합니다.
-  Spring MVC (`web` starter)와 WebFlux (`webflux` starter)가 공존할 때 발생하는 불확실성으로 보입니다. Spring Boot는 web 스타터가 있으면 기본적으로 Spring MVC로 동작하지만, 두 스택이 함께 있을 때 요청 핸들러 매핑에 혼선이 생겨 SockJS 요청이 잘못 처리될 수 있습니다. 이러한 불확실성을 제거하기 위해, 애플리케이션이 항상 서블릿(Servlet) 기반의 Spring MVC로 동작하도록 명시적으로 지정하는 방법을 제안합니다. 이 방법은 의존성을 제거하지 않고 설정만으로 문제를 해결할 수 있는 가장 안전한 접근 방식입니다.